### PR TITLE
Add round countdown timer UI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.27.2",
     "react": "^18.2.0",
+    "react-countdown-circle-timer": "^3.0.9",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",

--- a/frontend/src/components/CountdownView.js
+++ b/frontend/src/components/CountdownView.js
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { CountdownCircleTimer } from 'react-countdown-circle-timer';
+import Chip from '@mui/material/Chip';
+
+
+function CountdownView(props) {
+
+
+    const center = {
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+        fontSize: '20px'
+      };
+    
+    
+    const insideCircle = ({remainingTime}) => {
+        if (remainingTime === 0) {
+            return "Sorry, no match found";
+        } else {
+             return `${remainingTime}`;
+    }}
+
+    const messages = {
+        finding: "Finding a match...",
+        found: "Match found!",
+        notFound: "Sorry, no match found"
+    }
+
+    const[message, setMessage] = useState(messages.finding);
+
+
+    return (
+        <div style={center}>
+            <CountdownCircleTimer 
+                size={240}
+                isPlaying
+                duration={30}
+                colors={['#004777', '#F7B801', '#A30000', '#A30000']}
+                colorsTime={[30, 20, 10, 0]}
+                strokeWidth={12}
+                onComplete= {() => {
+                    setMessage(messages.notFound)
+                }}
+            >
+                {insideCircle}
+            </CountdownCircleTimer>
+            <Chip sx = {{ margin: 2 }} size="medium" label={message} variant="outlined" />
+        </div>
+    )
+}
+
+export default CountdownView;


### PR DESCRIPTION
fixes #6 

<img width="414" alt="Screenshot 2022-09-03 at 10 08 02 PM" src="https://user-images.githubusercontent.com/77088875/188274304-57802ce1-5d2d-40e6-bf9d-3afefacae594.png">


<img width="376" alt="Screenshot 2022-09-03 at 10 08 18 PM" src="https://user-images.githubusercontent.com/77088875/188274303-20c5f594-3281-4158-9110-2c0b6ed55911.png">

<img width="418" alt="Screenshot 2022-09-03 at 10 08 25 PM" src="https://user-images.githubusercontent.com/77088875/188274298-91f0ca01-d429-4f4d-aec1-bab3712c2de9.png">


- added frontend view for countdown timer using react-countdown-circle-timer package 
- used useState to change text of the chip below the timer 

