### PR TITLE
Update eslint to ignore import file extensions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,6 +32,13 @@
             {
               "code": 120
             }
+        ],
+
+        "import/extensions": [
+            "error",
+            {
+                "js": "ignorePackages"
+            }
         ]
     }
 }


### PR DESCRIPTION
Add eslint rule to ignore file extensions such as in 
![image](https://user-images.githubusercontent.com/12153882/189314992-630972f4-fc3d-4849-bd34-e6633a246658.png)

Omitting the file extensions crashes our program as seen in `Error [ERR_MODULE_NOT_FOUND]: Cannot find module xxx`
![image](https://user-images.githubusercontent.com/12153882/189315375-67e094c1-50b6-4be2-b8c5-55742cf675f9.png)

Hence the eslint rule is updated in this PR to ignore file extension inclusions in import statements.