### PR TITLE
All rooms and events related implementation supporting many socket instances

### DIFF
--- a/matching-service/controller/pendingMatchController.js
+++ b/matching-service/controller/pendingMatchController.js
@@ -10,19 +10,19 @@ const pendingMatchController = {
     getAvailableMatch: getAvailableMatch,
 };
 
-function addPendingMatchEasy(username, id) {
-    console.log(id);
-    pendingMatchOrm.addPendingMatchEasy(username);
+function addPendingMatchEasy(socketid, username) {
+    console.log(socketid);
+    pendingMatchOrm.addPendingMatchEasy(socketid, username);
 }
 
-function addPendingMatchMedium(username, id) {
-    console.log(id);
-    pendingMatchOrm.addPendingMatchMedium(username);
+function addPendingMatchMedium(socketid, username) {
+    console.log(socketid);
+    pendingMatchOrm.addPendingMatchMedium(socketid, username);
 }
 
-function addPendingMatchHard(username, id) {
-    console.log(id);
-    pendingMatchOrm.addPendingMatchHard(username);
+function addPendingMatchHard(socketid, username) {
+    console.log(socketid);
+    pendingMatchOrm.addPendingMatchHard(socketid, username);
 }
 
 function deletePendingMatchById(params) {

--- a/matching-service/controller/pendingMatchController.js
+++ b/matching-service/controller/pendingMatchController.js
@@ -25,8 +25,8 @@ function addPendingMatchHard(socketid, username) {
     pendingMatchOrm.addPendingMatchHard(socketid, username);
 }
 
-function deletePendingMatchById(params) {
-    pendingMatchOrm.deletePendingMatchById(params);
+function deletePendingMatchById(socketid) {
+    pendingMatchOrm.deletePendingMatchById(socketid);
 }
 
 // testing 22/09/2022

--- a/matching-service/controller/socketHandler/pendingMatchHandler.js
+++ b/matching-service/controller/socketHandler/pendingMatchHandler.js
@@ -33,9 +33,9 @@ const pendingMatchHandler = (io) => {
 
             // console.log(roomUsers);
 
-            // // for (const roomUser in roomUsers) {
-            // //     console.log(roomUser);
-            // // }
+            // for (const roomUser in roomUsers) {
+            //     console.log(roomUser);
+            // }
         });
 
         socket.on('match-medium', async (data) => {
@@ -68,8 +68,8 @@ const pendingMatchHandler = (io) => {
         });
 
         // no match found after 30s end
-        socket.on('no-match-found', (id) => {
-            pendingMatchController.deleteMatchByDifficulty(id);
+        socket.on('no-match-found', () => {
+            pendingMatchController.deletePendingMatchById(socket.id);
         });
 
         // pending match is cancelled before 30s ends

--- a/matching-service/controller/socketHandler/pendingMatchHandler.js
+++ b/matching-service/controller/socketHandler/pendingMatchHandler.js
@@ -24,9 +24,18 @@ const pendingMatchHandler = (io) => {
         });
 
         // join room based on socketid
-        socket.on('join-room', (socketid) => {
+        socket.on('join-room', async (socketid) => {
             socket.join(socketid);
             console.log('joined');
+
+            // Date: 4/10/2022 - This is just for demonstration later
+            // const roomUsers = await io.in(socketid).fetchSockets();
+
+            // console.log(roomUsers);
+
+            // // for (const roomUser in roomUsers) {
+            // //     console.log(roomUser);
+            // // }
         });
 
         socket.on('match-medium', async (data) => {

--- a/matching-service/controller/socketHandler/pendingMatchHandler.js
+++ b/matching-service/controller/socketHandler/pendingMatchHandler.js
@@ -67,19 +67,14 @@ const pendingMatchHandler = (io) => {
             }
         });
 
-        // no match found after 30s end
+        // no match found after 30s ends
         socket.on('no-match-found', () => {
             pendingMatchController.deletePendingMatchById(socket.id);
         });
 
         // pending match is cancelled before 30s ends
-        // alternative idea: a particular-room receive cancel-match event
-        // then destroy all pending match in that room
-        // socket.on('match-cancel', (id) => {
-        //     pendingMatchController.deletePendingMatchById(id);
-        // });
-        socket.on('match-cancel', (username) => {
-            pendingMatchController.deletePendingMatchByUsername(username);
+        socket.on('match-cancel', () => {
+            pendingMatchController.deletePendingMatchById(socket.id);
         });
 
         // leaves room after matched

--- a/matching-service/controller/socketHandler/pendingMatchHandler.js
+++ b/matching-service/controller/socketHandler/pendingMatchHandler.js
@@ -77,10 +77,13 @@ const pendingMatchHandler = (io) => {
             pendingMatchController.deletePendingMatchById(socket.id);
         });
 
-        // leaves room after matched
-        // takes room id
-        // emit event to that room and destroy all matches in that room
-        socket.on('leave-room', () => {});
+        // leaves room after matched and already in the same room
+        // note: once someone leave the room, the event should be emitted to both users in the room
+        socket.on('leave-room', async (socketRoomId) => {
+            socket.leave(socketRoomId);
+            // const roomUsers = await io.in(socketRoomId).fetchSockets();
+            // console.log(roomUsers);
+        });
     });
 };
 

--- a/matching-service/controller/socketHandler/pendingMatchHandler.js
+++ b/matching-service/controller/socketHandler/pendingMatchHandler.js
@@ -2,14 +2,19 @@ import pendingMatchController from '../pendingMatchController.js';
 
 const pendingMatchHandler = (io) => {
     io.on('connection', (socket) => {
+        console.log(socket.id);
         socket.on('match-easy', async (data) => {
             socket.join('easy-waiting-room');
             const user = await pendingMatchController.getAvailableMatch('easy');
             // if no match --> add to db
             if (user === null) {
-                pendingMatchController.addPendingMatchEasy(data, socket.rooms);
+                // pendingMatchController.addPendingMatchEasy(data, socket.rooms);
+                pendingMatchController.addPendingMatchEasy(socket.id, data);
             } else {
                 io.to('easy-waiting-room').emit('match-success', socket.rooms);
+                /**
+                 * make all socket instances
+                 */
                 // else --> match and delete
                 pendingMatchController.deleteMatchByDifficulty('easy');
             }
@@ -19,7 +24,7 @@ const pendingMatchHandler = (io) => {
             socket.join('medium-waiting-room');
             const user = await pendingMatchController.getAvailableMatch('medium');
             if (user === null) {
-                pendingMatchController.addPendingMatchMedium(data, socket.rooms);
+                pendingMatchController.addPendingMatchMedium(socket.id, data);
             } else {
                 io.to('medium-waiting-room').emit('match-success', socket.rooms);
                 pendingMatchController.deleteMatchByDifficulty('medium');
@@ -30,10 +35,10 @@ const pendingMatchHandler = (io) => {
             socket.join('hard-waiting-room');
             const user = await pendingMatchController.getAvailableMatch('hard');
             if (user === null) {
-                pendingMatchController.addPendingMatchHard(data, socket.id);
+                pendingMatchController.addPendingMatchHard(socket.id, data);
             } else {
                 pendingMatchController.deleteMatchByDifficulty('hard');
-                io.to('hard-waiting-room').emit('match-success', socket.id);
+                io.to('hard-waiting-room').emit('match-success', socket.rooms);
             }
         });
 

--- a/matching-service/index.js
+++ b/matching-service/index.js
@@ -36,6 +36,7 @@ app.get('/', (req, res) => {
 globalHandler(io);
 // handle pending match events
 // pendingMatchHandler(addUserIo);
+// server is at localhost:8001
 pendingMatchHandler(io);
 
 httpServer.listen(PORT, () => {

--- a/matching-service/model/orm.js
+++ b/matching-service/model/orm.js
@@ -32,8 +32,8 @@ function deleteByUsername(username) {
     return PendingMatch.destroy({ where: { username: username } });
 }
 
-function deleteById(id) {
-    return PendingMatch.destroy({ where: { id: id } });
+function deleteById(socketid) {
+    return PendingMatch.destroy({ where: { socketid: socketid } });
 }
 
 async function deleteMatchByDifficulty(difficulty) {

--- a/matching-service/model/pendingMatchModel.js
+++ b/matching-service/model/pendingMatchModel.js
@@ -3,16 +3,14 @@ import db from './repository.js';
 
 const PendingMatch = db.define('pendingMatches', {
     // define match model attributes
-    id: {
-        type: DataTypes.INTEGER,
-        primaryKey: true,
+    socketid: {
+        type: DataTypes.STRING,
         allowNull: false,
         unique: true,
-        autoIncrement: true,
     },
     username: {
         type: DataTypes.STRING,
-        allowNull: false,
+        allowNull: true,
         unique: true,
     },
     difficulty: {

--- a/matching-service/model/pendingMatchOrm.js
+++ b/matching-service/model/pendingMatchOrm.js
@@ -40,8 +40,8 @@ function addPendingMatchHard(socketid, username) {
     return orm.create(details);
 }
 
-function deletePendingMatchById(params) {
-    return orm.deleteById(params.id);
+function deletePendingMatchById(socketid) {
+    return orm.deleteById(socketid);
 }
 // testing only
 function deletePendingMatchByUsername(params) {

--- a/matching-service/model/pendingMatchOrm.js
+++ b/matching-service/model/pendingMatchOrm.js
@@ -10,8 +10,9 @@ const pendingMatchOrm = {
     getAvailableMatch: getAvailableMatch,
 };
 
-function addPendingMatchEasy(username) {
+function addPendingMatchEasy(socketid, username) {
     const details = {
+        socketid: socketid,
         username: username.username,
         difficulty: 'easy',
     };
@@ -19,8 +20,9 @@ function addPendingMatchEasy(username) {
     return orm.create(details);
 }
 
-function addPendingMatchMedium(username) {
+function addPendingMatchMedium(socketid, username) {
     const details = {
+        socketid: socketid,
         username: username.username,
         difficulty: 'medium',
     };
@@ -28,8 +30,9 @@ function addPendingMatchMedium(username) {
     return orm.create(details);
 }
 
-function addPendingMatchHard(username) {
+function addPendingMatchHard(socketid, username) {
     const details = {
+        socketid: socketid,
         username: username.username,
         difficulty: 'hard',
     };


### PR DESCRIPTION
Fixes #82, #80, #54, #55, #56

## Update on schema
```javascript
socketid: {
        type: DataTypes.STRING,
        allowNull: false,
        unique: true,
}
```
- remove primary key since it is redundant
- id is auto incremented and auto generated by sequelize
- pass in socketid of the socket instance instead, which is uniquely identified
- example of pendingMatch instance; username is made `allowNull: true` just to keep the attribute for now in case we need it for other things like chat service 

<img src="https://user-images.githubusercontent.com/60144099/193657519-02e47f9e-2c55-46eb-9de7-5476b363c61e.jpeg"  width="400" height="300"/>

## What does this update mean?
- This mean that most things will be done through the socket instance. For example, previously we pass in username and difficulty level when creating a pendingMatch instance. This update allow the creation of pendingMatch instance purely through event (e.g. `match-easy` event --> creates pendingMatch instance with `difficulty: easy` provided there is no match)

## Room allocation
Logical flow:
1. Client side receive a `match-success` event. The additional arguments passed along with the `match-success` event are socketid of the first client and the second client.
2. Client side emit a `join-room` event upon successful receive of `match-success`. The extra argument passed along with the `join-room` event is the socketid of the **first** client connected with the particular difficulty chosen. (@dionegoh need your help to emit this `join-room` event once the `match-success` is received 😄, thanks!)

## Testing - Room allocation
1. Object creation/deletion on matched (same as the previous PR). Trivial.
2. `match-success` is emitted upon matched
3. Only the matched clients received the `match-success` event
4. Upon emitting `join-room` event to the matched clients, both clients will joined the same room with the **room id being the socket of the first client**. The room should only contain 2 socket instances, with respective id

## `no-match-found` event listener
- Once a client side receive a `no-match-found` event, the client will be removed from the *pendingMatches* database

## Testing - `no-match-found` event
Link to demo: https://drive.google.com/file/d/1pPmfEPXiW9N7Q8T8hXVBz7GTyYZERlRh/view?usp=sharing

## `match-cancel` event listener
- Delete the client from the *pendingMatches* database on the receive of `match-cancel` event

## Testing - `match-cancel` event 
Link to demo: https://drive.google.com/file/d/1Zibegt7AgQDRVyFAFuHow-yqUlNYYnyD/view?usp=sharing

## `leave-room` event listener
- Once received, the socket will leave the room
- Note: on the client side, the `leave-room` event should be emitted to both users in the room (identified by the id of the first user) (@dionegoh)

## Testing - `leave-room` event
Link to demo: https://drive.google.com/file/d/1jyyPgKisiK91S_YCg2ymchJyudimhYvC/view?usp=sharing