### PR TITLE
Match frontend events to backend 

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -9,11 +9,9 @@ import {Box} from "@mui/material";
 
 function App() {
 
-    const [socket, setSocket] = useState();
-
     return (
         <div className="App">
-            <SocketContext.Provider value={[socket, setSocket]}>
+            {/* <SocketContext.Provider value={[socket, setSocket]}> */}
                 {/* <Box display={"flex"} flexDirection={"column"} padding={"4rem"}> */}
                 <Router>
                     <Routes>
@@ -25,7 +23,7 @@ function App() {
                     </Routes>
                 </Router>
             {/* </Box> */}
-            </SocketContext.Provider>
+            {/* </SocketContext.Provider> */}
         </div>
     );
 }

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,24 +1,31 @@
+import React, { useState } from 'react';
 import {BrowserRouter as Router, Routes, Route, Navigate} from "react-router-dom";
 import SignupPage from './components/SignupPage';
 import SelectionView from './components/MatchingService/SelectionView';
 import CountdownView from './components/MatchingService/CountdownView';
 import RoomPage from './components/MatchingService/RoomPage'
+import {SocketContext} from './components/MatchingService/SocketContext';
 import {Box} from "@mui/material";
 
 function App() {
+
+    const [socket, setSocket] = useState();
+
     return (
         <div className="App">
-            {/* <Box display={"flex"} flexDirection={"column"} padding={"4rem"}> */}
+            <SocketContext.Provider value={[socket, setSocket]}>
+                {/* <Box display={"flex"} flexDirection={"column"} padding={"4rem"}> */}
                 <Router>
                     <Routes>
                         <Route exact path="/" element={<Navigate replace to="/signup" />}></Route>
                         <Route path="/signup" element={<SignupPage/>}/>
-                        <Route path="/selectquestiondifficulty" element={<SelectionView/>}></Route>
-                        <Route path="/findingmatch" element={<CountdownView/>}></Route>
-                        <Route path="/roompage" element={<RoomPage/>}></Route>
+                            <Route path="/selectquestiondifficulty" element={<SelectionView/>}></Route>
+                            <Route path="/findingmatch" element={<CountdownView/>}></Route>
+                            <Route path="/roompage" element={<RoomPage/>}></Route>
                     </Routes>
                 </Router>
             {/* </Box> */}
+            </SocketContext.Provider>
         </div>
     );
 }

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -89,8 +89,10 @@ function CountdownView(props) {
 
                 <Button variant="outlined" sx={{margin: 1}} 
                     onClick={() => {
+                        if (matchingStatus === 'match-finding') {
+                            socket.emit('match-cancel');
+                        }
                         setMatchingStatus('match-finding');
-                        socket.emit('match-cancel');
                         socket.disconnect();
                         props.handleCloseModal();
                      }}> Cancel </Button>

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -50,9 +50,10 @@ function CountdownView(props) {
 
     socket.on("match-success", (firstClientSocketId, secondClientSocketId) => {
             setMatchingStatus('match-success');
+            console.log("hi");
+            console.log(firstClientSocketId);
             socket.emit("join-room", firstClientSocketId);
-            navigate('/roompage',
-                { state: { roomId: firstClientSocketId,
+            navigate('/roompage', {state: { roomId: firstClientSocketId,
                     secondClientSocketId: secondClientSocketId,
                     socket: socket }} );
         }

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -50,12 +50,11 @@ function CountdownView(props) {
 
     socket.on("match-success", (firstClientSocketId, secondClientSocketId) => {
             setMatchingStatus('match-success');
-            console.log("hi");
             console.log(firstClientSocketId);
             socket.emit("join-room", firstClientSocketId);
             navigate('/roompage', {state: { roomId: firstClientSocketId,
-                    secondClientSocketId: secondClientSocketId,
-                    socket: socket }} );
+                    secondClientSocketId: secondClientSocketId
+                    }} );
         }
     );
         

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -72,10 +72,7 @@ function CountdownView(props) {
                     strokeWidth={12}
                     onComplete= {() => {
                         setMatchingStatus('match-fail')
-
-                        //hard-coded difficulty level temporarily
-                        socket.emit('no-match-found', "easy");
-        
+                        socket.emit('no-match-found');
                         console.log('failed');
                     }}
                 >
@@ -88,7 +85,7 @@ function CountdownView(props) {
                     onClick={() => {
                         setMatchingStatus('match-finding');
                         console.log('psst');
-                        socket.emit('match-cancel', { username: "John" });
+                        socket.emit('match-cancel');
                         props.handleCloseModal();
                      }}> Cancel </Button>
             </div>

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -72,7 +72,10 @@ function CountdownView(props) {
                     strokeWidth={12}
                     onComplete= {() => {
                         setMatchingStatus('match-fail')
-                        socket.emit('no-match-found');
+
+                        //hard-coded difficulty level temporarily
+                        socket.emit('no-match-found', "easy");
+        
                         console.log('failed');
                     }}
                 >

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -51,7 +51,10 @@ function CountdownView(props) {
     socket.on("match-success", (firstClientSocketId, secondClientSocketId) => {
             setMatchingStatus('match-success');
             socket.emit("join-room", firstClientSocketId);
-            navigate('/roompage', { state: { roomId: firstClientSocketId, secondClientSocketId: secondClientSocketId}} );
+            navigate('/roompage',
+                { state: { roomId: firstClientSocketId,
+                    secondClientSocketId: secondClientSocketId,
+                    socket: socket }} );
         }
     );
         

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -35,6 +35,8 @@ function CountdownView(props) {
         notFound: "Sorry, no match found"
     }
 
+
+    //three possible states for matching status: match-finding, match-success, and match-fail
     const[matchingStatus, setMatchingStatus] = useState('match-finding');
     const navigate = useNavigate();
 
@@ -46,7 +48,14 @@ function CountdownView(props) {
     const socket = props.socket;
     console.log(socket);
 
-    socket.on("match-success", () => setMatchingStatus('match-success'));
+    socket.on("match-success", (firstClientSocketId, secondClientSocketId) => {
+            setMatchingStatus('match-success');
+            socket.emit("join-room", firstClientSocketId);
+            navigate('/roompage', { state: { roomId: firstClientSocketId, secondClientSocketId: secondClientSocketId}} );
+        }
+    );
+        
+
     socket.on("match-failure", () => setMatchingStatus('match-fail'));
 
     const insideCircle = ({remainingTime}) => {
@@ -55,10 +64,6 @@ function CountdownView(props) {
         } else {
              return `${remainingTime}`;
     }}
-
-    if (matchingStatus === 'match-success') {
-        navigate('/roompage');
-    }
 
     return (
         <div style={modal}>
@@ -84,7 +89,6 @@ function CountdownView(props) {
                 <Button variant="outlined" sx={{margin: 1}} 
                     onClick={() => {
                         setMatchingStatus('match-finding');
-                        console.log('psst');
                         socket.emit('match-cancel');
                         props.handleCloseModal();
                      }}> Cancel </Button>

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -59,8 +59,6 @@ function CountdownView(props) {
     );
         
 
-    socket.on("match-failure", () => setMatchingStatus('match-fail'));
-
     const insideCircle = ({remainingTime}) => {
         if (remainingTime === 0) {
             return "Sorry, no match found";

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -1,10 +1,13 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
+import { SocketContext } from './SocketContext'
 import {useNavigate} from 'react-router-dom';
 import { CountdownCircleTimer } from 'react-countdown-circle-timer';
 import Button from '@mui/material/Button';
 
 
 function CountdownView(props) {
+
+    const[socket, setSocket] = useContext(SocketContext);
 
     const modal = {
         position: 'fixed',
@@ -45,7 +48,6 @@ function CountdownView(props) {
         return null;
     }
 
-    const socket = props.socket;
     console.log(socket);
 
     socket.on("match-success", (firstClientSocketId, secondClientSocketId) => {

--- a/frontend/src/components/MatchingService/CountdownView.js
+++ b/frontend/src/components/MatchingService/CountdownView.js
@@ -90,6 +90,7 @@ function CountdownView(props) {
                     onClick={() => {
                         setMatchingStatus('match-finding');
                         socket.emit('match-cancel');
+                        socket.disconnect();
                         props.handleCloseModal();
                      }}> Cancel </Button>
             </div>

--- a/frontend/src/components/MatchingService/DifficultyCard.js
+++ b/frontend/src/components/MatchingService/DifficultyCard.js
@@ -26,7 +26,7 @@ export default function DifficultyCard(props) {
     });
 
     //null value to be passed in for username for now 
-    socket.emit(`match-${props.difficulty}`, null);
+    socket.emit(`match-${props.difficulty}`, {});
     props.handleOpenModal(socket);
   }
 

--- a/frontend/src/components/MatchingService/DifficultyCard.js
+++ b/frontend/src/components/MatchingService/DifficultyCard.js
@@ -14,14 +14,14 @@ import { io } from "socket.io-client";
 
 export default function DifficultyCard(props) {
 
-  const[socket, setSocket] = useContext(SocketContext);
+  const { getSocket } = useContext(SocketContext);
 
   const handleFindMatchClick = (e) => {
     e.preventDefault();
     console.log(`${props.difficulty} button was clicked`);
 
-    const socket = io("http://localhost:8001");
-    setSocket(socket);
+    const socket = getSocket();
+    
     socket.on("connect", () => {
       console.log(socket.connected); // true
     });

--- a/frontend/src/components/MatchingService/DifficultyCard.js
+++ b/frontend/src/components/MatchingService/DifficultyCard.js
@@ -1,5 +1,5 @@
 import React,{ useContext } from 'react';
-import {SocketContext} from './SocketContext'
+import { SocketContext } from './SocketContext'
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';

--- a/frontend/src/components/MatchingService/DifficultyCard.js
+++ b/frontend/src/components/MatchingService/DifficultyCard.js
@@ -25,8 +25,8 @@ export default function DifficultyCard(props) {
       console.log(socket.connected); // true
     });
 
-    // testing 22/09/2022: hard-coded username
-    socket.emit(`match-${props.difficulty}`, { username: "John" });
+    //null value to be passed in for username for now 
+    socket.emit(`match-${props.difficulty}`, null);
     props.handleOpenModal(socket);
   }
 

--- a/frontend/src/components/MatchingService/DifficultyCard.js
+++ b/frontend/src/components/MatchingService/DifficultyCard.js
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import React,{ useContext } from 'react';
+import {SocketContext} from './SocketContext'
 import Button from '@mui/material/Button';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
@@ -13,14 +14,14 @@ import { io } from "socket.io-client";
 
 export default function DifficultyCard(props) {
 
+  const[socket, setSocket] = useContext(SocketContext);
+
   const handleFindMatchClick = (e) => {
     e.preventDefault();
     console.log(`${props.difficulty} button was clicked`);
 
     const socket = io("http://localhost:8001");
-    // const socket = io.of('/pendingMatches');
-    // const socket = io("http://localhost:8001/pendingMatches")
-
+    setSocket(socket);
     socket.on("connect", () => {
       console.log(socket.connected); // true
     });

--- a/frontend/src/components/MatchingService/RoomPage.js
+++ b/frontend/src/components/MatchingService/RoomPage.js
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import {useNavigate, useLocation, Navigate} from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
@@ -7,7 +8,20 @@ import Typography from "@mui/material/Typography";
 import LogoutIcon from '@mui/icons-material/Logout';
 
 
-export default function RoomPage() {
+export default function RoomPage({ socket }) {
+
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const roomId = location.state.roomId;
+    const secondClientSocketId = location.state.secondClientSocketId;
+
+    function onLeaveHandler() {
+        socket.emit("leave-room", roomId);
+        navigate('/selectquestiondifficulty');
+        socket.disconnect();
+    }
+
     return (
             <Grid container spacing={0.5} sx={{backgroundColor:'white', width:'100vw', height:'100vh', margin: '0px'}}>
                 {/* left panel */}
@@ -15,8 +29,8 @@ export default function RoomPage() {
                     <Stack spacing={0.5}>
                         {/* room number and leave room button */}
                         <Box sx={{height: "9.5vh", display:'flex', justifyContent:'flex-start', alignItems:'center', backgroundColor: 'white'}}>
-                            <Typography variant="h6" sx={{margin: 2}}> Room {110} </Typography> 
-                            <Button variant="outlined" endIcon={<LogoutIcon />}>
+                            <Typography variant="h6" sx={{margin: 2}}> Room {roomId} </Typography> 
+                            <Button variant="outlined" endIcon={<LogoutIcon />} onClick={onLeaveHandler}>
                               Leave Room 
                             </Button>    
                         </Box>

--- a/frontend/src/components/MatchingService/RoomPage.js
+++ b/frontend/src/components/MatchingService/RoomPage.js
@@ -13,6 +13,7 @@ export default function RoomPage() {
     const location = useLocation();
     const navigate = useNavigate();
 
+    console.log(location);
     const roomId = location.state.roomId;
     const secondClientSocketId = location.state.secondClientSocketId;
     const socket = location.state.socket;

--- a/frontend/src/components/MatchingService/RoomPage.js
+++ b/frontend/src/components/MatchingService/RoomPage.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import {useNavigate, useLocation, Navigate} from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
 import Grid from '@mui/material/Grid';
@@ -8,13 +8,14 @@ import Typography from "@mui/material/Typography";
 import LogoutIcon from '@mui/icons-material/Logout';
 
 
-export default function RoomPage({ socket }) {
+export default function RoomPage() {
 
     const location = useLocation();
     const navigate = useNavigate();
 
     const roomId = location.state.roomId;
     const secondClientSocketId = location.state.secondClientSocketId;
+    const socket = location.state.socket;
 
     function onLeaveHandler() {
         socket.emit("leave-room", roomId);

--- a/frontend/src/components/MatchingService/RoomPage.js
+++ b/frontend/src/components/MatchingService/RoomPage.js
@@ -1,4 +1,4 @@
-import React,{ useContext } from 'react';
+import React,{ useContext, useEffect, useRef } from 'react';
 import { SocketContext } from './SocketContext'
 import { useNavigate, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
@@ -7,11 +7,23 @@ import Grid from '@mui/material/Grid';
 import Stack from '@mui/material/Stack';
 import Typography from "@mui/material/Typography";
 import LogoutIcon from '@mui/icons-material/Logout';
+import { io } from "socket.io-client";
+
 
 
 export default function RoomPage() {
 
-    const[socket, setSocket] = useContext(SocketContext);
+    const { getSocket } = useContext(SocketContext);
+    let socket = getSocket();
+    
+
+    // useEffect( () => {
+    //     if (! socket) {
+    //     console.log("hi");
+    //     const reconnectedSocket = io("http://localhost:8001");
+    //     setSocket(reconnectedSocket);
+    //     console.log(reconnectedSocket);
+    //     }}, []);
 
     const location = useLocation();
     const navigate = useNavigate();
@@ -19,12 +31,27 @@ export default function RoomPage() {
     console.log(location);
     const roomId = location.state.roomId;
     console.log("roomId" + roomId);
+    console.log("socketID " + socket.id);
+
     const secondClientSocketId = location.state.secondClientSocketId;
+
+    useEffect( () => {
+        socket.on("connect", () => {
+            console.log(socket.connected); // true
+          });
+        socket.emit("join-room", roomId);
+
+        return () => {
+            socket.disconnect();
+            socket.connect();
+        } 
+
+    }, []);
     
     function onLeaveHandler() {
+        console.log("leaving " + socket.id);
         socket.emit("leave-room", roomId);
         navigate('/selectquestiondifficulty');
-        socket.disconnect();
     }
 
     return (

--- a/frontend/src/components/MatchingService/RoomPage.js
+++ b/frontend/src/components/MatchingService/RoomPage.js
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import React,{ useContext } from 'react';
+import { SocketContext } from './SocketContext'
 import { useNavigate, useLocation } from 'react-router-dom';
 import Box from '@mui/material/Box';
 import Button from '@mui/material/Button';
@@ -10,14 +11,16 @@ import LogoutIcon from '@mui/icons-material/Logout';
 
 export default function RoomPage() {
 
+    const[socket, setSocket] = useContext(SocketContext);
+
     const location = useLocation();
     const navigate = useNavigate();
 
     console.log(location);
     const roomId = location.state.roomId;
+    console.log("roomId" + roomId);
     const secondClientSocketId = location.state.secondClientSocketId;
-    const socket = location.state.socket;
-
+    
     function onLeaveHandler() {
         socket.emit("leave-room", roomId);
         navigate('/selectquestiondifficulty');

--- a/frontend/src/components/MatchingService/SelectionView.js
+++ b/frontend/src/components/MatchingService/SelectionView.js
@@ -1,4 +1,5 @@
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
+import { SocketContext } from './SocketContext'
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 import DifficultyCard from './DifficultyCard';
@@ -8,13 +9,12 @@ import CountdownView from './CountdownView';
 export default function SelectionView() {
     const difficultyLevels = ["easy", "medium", "hard"];
     const [showModal, setShowModal] = useState(false);
-    const [socket, setSocket] = useState(null);
+    const[socket, setSocket] = useContext(SocketContext);
 
-    const handleOpenModal = (socket) => {
+    const handleOpenModal = () => {
       setShowModal(true);
       console.log('Countdown timer modal opened');
-      setSocket(socket);
-      console.log(socket);
+  
     }
 
     const handleCloseModal = (e) => {
@@ -29,7 +29,7 @@ export default function SelectionView() {
                  <Grid key={difficultyLevel} item xs={'auto'}>
                      <DifficultyCard difficulty={difficultyLevel} handleOpenModal={handleOpenModal}/>
                 </Grid>)}
-                <CountdownView show={showModal} handleCloseModal={handleCloseModal} socket={socket} />
+                <CountdownView show={showModal} handleCloseModal={handleCloseModal} />
           </Grid>
         </Box>
       );

--- a/frontend/src/components/MatchingService/SelectionView.js
+++ b/frontend/src/components/MatchingService/SelectionView.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { SocketContext } from './SocketContext'
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
@@ -7,19 +7,18 @@ import CountdownView from './CountdownView';
 
 
 export default function SelectionView() {
+
     const difficultyLevels = ["easy", "medium", "hard"];
     const [showModal, setShowModal] = useState(false);
-    const[socket, setSocket] = useContext(SocketContext);
+
 
     const handleOpenModal = () => {
       setShowModal(true);
-      console.log('Countdown timer modal opened');
   
     }
 
     const handleCloseModal = (e) => {
       setShowModal(false);
-      console.log('Countdown timer modal close');
     }
 
     return (

--- a/frontend/src/components/MatchingService/SocketContext.js
+++ b/frontend/src/components/MatchingService/SocketContext.js
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export const SocketContext = createContext(); 

--- a/frontend/src/components/MatchingService/SocketContext.js
+++ b/frontend/src/components/MatchingService/SocketContext.js
@@ -1,3 +1,21 @@
 import { createContext } from 'react';
+import { io } from "socket.io-client";
 
-export const SocketContext = createContext(); 
+let socket; 
+
+function initSocket() {
+    socket = io("http://localhost:8001");
+    return socket;
+}
+
+function getSocket() {
+    if (! socket) {
+        initSocket();
+    } 
+    return socket; 
+}
+
+
+export const SocketContext = createContext({
+    getSocket: getSocket
+}); 


### PR DESCRIPTION
Summary of events emitted from frontend:

- `socket.emit(match-easy, {})`, where {} represents username 

- `socket.emit(match-medium, {})`, where {} represents username 

- `socket.emit(match-hard, {})`, where {} represents username 

- `socket.emit(match-cancel)`

- `socket.emit(no-match-found)` 

-`socket.emit(join-room, socketID_of_first_client)`

- `socket.emit(leave-room, socketID_of_first_client)`


Summary of events that frontend is listening to:

- `match-success` : upon receiving, will direct client to roompage with roomID being the first client's socketID


Changes made
- created `socketContext.js` file, to initialise and store the socket details 
- fixed bug where users cannot leave room upon refreshing room page 

fixes #83 #76 
