### PR TITLE
Implement collaborative functionality of code editor 

### DIFF
--- a/collaboration-service/index.js
+++ b/collaboration-service/index.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import cors from 'cors';
+import { createServer } from 'http';
+import { Server } from 'socket.io';
+import socketHandler from './socketHandler.js';
+
+const app = express();
+const httpServer = createServer(app);
+const PORT = process.env.PORT || 8002;
+
+// io
+const io = new Server(httpServer, {
+    cors: {
+        cors: {
+            origin: 'http://localhost:3000',
+        },
+    },
+});
+
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+app.use(cors()); // config cors so that front-end can use
+// app.use('/', routes);
+app.options('*', cors());
+app.get('/', (req, res) => {
+    res.send('Hello World from collaboration-service');
+});
+
+//to log onto console when client is connected 
+socketHandler(io);
+
+
+httpServer.listen(PORT, () => {
+    console.log(`listening on port ${PORT}`);
+});

--- a/collaboration-service/package.json
+++ b/collaboration-service/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "collaboration-service",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "type": "module",
+  "scripts": {
+    "start": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "socket.io": "^4.5.2"
+  }
+}

--- a/collaboration-service/socketHandler.js
+++ b/collaboration-service/socketHandler.js
@@ -6,9 +6,17 @@ const socketHandler = (io) => {
             console.log('a user disconnected');
         });
 
-        socket.on('on-keypress', (text) => {
+        socket.on('on-keypress', (text, roomId) => {
             console.log(text);
-        })
+            socket.to(roomId).emit('sync-text', text);
+        });
+
+        // join collab service based on socketid
+        socket.on('join-collab-service', async (roomid) => {
+            socket.join(roomid);
+            console.log('joined');
+        });
+
     });
 };
 

--- a/collaboration-service/socketHandler.js
+++ b/collaboration-service/socketHandler.js
@@ -1,0 +1,15 @@
+const socketHandler = (io) => {
+    io.on('connection', (socket) => {
+        console.log('a user connected');
+
+        socket.on('disconnect', () => {
+            console.log('a user disconnected');
+        });
+
+        socket.on('on-keypress', (text) => {
+            console.log(text);
+        })
+    });
+};
+
+export default socketHandler;

--- a/frontend/src/components/CollaborationService/CodeEditor.js
+++ b/frontend/src/components/CollaborationService/CodeEditor.js
@@ -1,4 +1,5 @@
-import React, { useEffect } from 'react';
+import React, { useContext, useEffect } from 'react';
+import { SocketContext } from './SocketContext'
 import CodeMirror from '@uiw/react-codemirror';
 import { dracula } from '@uiw/codemirror-theme-dracula';
 import { javascript } from '@codemirror/lang-javascript';
@@ -11,6 +12,12 @@ import { basicSetup, minimalSetup } from '@uiw/codemirror-extensions-basic-setup
 import Box from '@mui/material/Box';
 
 const CodeEditor = () => {
+
+    //getting socket
+    const { getSocket } = useContext(SocketContext);
+    let socket = getSocket();
+    console.log(socket);
+
     const code = '/*Type in your solution below*/';
     
     return (
@@ -34,6 +41,8 @@ const CodeEditor = () => {
                 ]}
                 onChange={(value, viewUpdate) => {
                     console.log('value:', value);
+                    socket.emit("on-keypress", { value: value,
+                                                 });
                 }}
             />
         </div>

--- a/frontend/src/components/CollaborationService/SocketContext.js
+++ b/frontend/src/components/CollaborationService/SocketContext.js
@@ -1,0 +1,21 @@
+import { createContext } from 'react';
+import { io } from "socket.io-client";
+
+let socket; 
+
+function initSocket() {
+    socket = io("http://localhost:8002");
+    return socket;
+}
+
+function getSocket() {
+    if (! socket) {
+        initSocket();
+    } 
+    return socket; 
+}
+
+
+export const SocketContext = createContext({
+    getSocket: getSocket
+}); 

--- a/frontend/src/components/MatchingService/RoomPage.js
+++ b/frontend/src/components/MatchingService/RoomPage.js
@@ -86,7 +86,7 @@ export default function RoomPage() {
                 <Grid item xs={6.98} md={6.98} sx={{height: "100vh"}}>
                     <Stack spacing={0}>
                         {/* code box */}
-                        <CodeEditor />
+                        <CodeEditor roomId={roomId} />
                     </Stack>
                 </Grid>
             </Grid>


### PR DESCRIPTION
### Summary of changes made:

fixes #93 

- to decouple `matching-service` and `collaboration-service`, instantiated a new socket for each client in `collaboration-service`, **using `roomId` as a key to join the sockets together**

- implemented socket.io event emitters and listeners to listen for keypresses and emitting the updated text value to clients in the room. 

- stored the text temporarily using `windows.sessionStorage` to prevent code from disappearing upon refresh 

### To test: 
- cd into `matching-service`, and run `node index`
- cd into `collaboration-service`, and run `node index`
- cd into `frontend`, and run `npm start`  
(make sure to run `npm i` to install relevant dependencies not done)

- open 2 browsers at `localhost:3000/selectquestiondifficulty` and select a match of the same difficulty level for each browser. check the 2 browsers are matched to the same room (the roomId is the same) 

- enter some text into the code editor 

- check that the text changes are reflected in the **other** browser that did not enter the text **in real time** 

- also check that refreshing the page will not cause the text to disappear, and that the user can continue typing in the code editor afterwards 


<img width="1440" alt="image" src="https://user-images.githubusercontent.com/77088875/194916335-85668fed-9ed9-44c8-aa12-a34fafe3af43.png">
