### PR TITLE
Implement UI for Delete Account

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,7 +32,7 @@ function App() {
                     <Route path="/signup" element={<SignupPage />} />
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/logout" element={<LogoutPage />} />
-                    <Route path="deleteAccount" element={<DeleteAccountPage />} />
+                    <Route path="/deleteAccount" element={<DeleteAccountPage />} />
                     {/* Placeholder home for matching-service */}
                     <Route path="/" element={<WithNavBar />}>
                         <Route path="home" element={<Home />} />

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import ChangePasswordPage from "./components/ChangePasswordPage";
 import LoginPage from "./components/LoginPage";
 import LogoutPage from "./components/LogoutPage";
 import Home from "./components/Home";
+import DeleteAccountPage from "./components/DeleteAccountPage";
 import SelectionView from './components/MatchingService/SelectionView';
 import CountdownView from './components/MatchingService/CountdownView';
 import RoomPage from './components/MatchingService/RoomPage'
@@ -16,7 +17,7 @@ function WithNavBar() {
             <Outlet />
         </>
     )
-    
+
 }
 
 
@@ -28,18 +29,19 @@ function App() {
             <Router>
                 <Routes>
                     <Route exact path="/" element={<Navigate replace to="/signup" />}></Route>
-                    <Route path="/signup" element={<SignupPage/>}/>
+                    <Route path="/signup" element={<SignupPage />} />
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/logout" element={<LogoutPage />} />
                     {/* Placeholder home for matching-service */}
                     <Route path="/" element={<WithNavBar />}>
                         <Route path="home" element={<Home />} />
-                        <Route path="changePassword" element={<ChangePasswordPage/>}/>
-                        <Route path="selectquestiondifficulty" element={<SelectionView/>}></Route>
-                        <Route path="findingmatch" element={<CountdownView/>}></Route>
-                        <Route path="roompage" element={<RoomPage/>}></Route>
+                        <Route path="changePassword" element={<ChangePasswordPage />} />
+                        <Route path="deleteAccount" element={<DeleteAccountPage />} />
+                        <Route path="selectquestiondifficulty" element={<SelectionView />}></Route>
+                        <Route path="findingmatch" element={<CountdownView />}></Route>
+                        <Route path="roompage" element={<RoomPage />}></Route>
                     </Route>
-                    
+
                 </Routes>
             </Router>
             {/* </Box> */}

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -32,11 +32,11 @@ function App() {
                     <Route path="/signup" element={<SignupPage />} />
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/logout" element={<LogoutPage />} />
+                    <Route path="deleteAccount" element={<DeleteAccountPage />} />
                     {/* Placeholder home for matching-service */}
                     <Route path="/" element={<WithNavBar />}>
                         <Route path="home" element={<Home />} />
                         <Route path="changePassword" element={<ChangePasswordPage />} />
-                        <Route path="deleteAccount" element={<DeleteAccountPage />} />
                         <Route path="selectquestiondifficulty" element={<SelectionView />}></Route>
                         <Route path="findingmatch" element={<CountdownView />}></Route>
                         <Route path="roompage" element={<RoomPage />}></Route>

--- a/frontend/src/components/DeleteAccountAlert.js
+++ b/frontend/src/components/DeleteAccountAlert.js
@@ -6,19 +6,13 @@ import DialogContent from '@mui/material/DialogContent';
 import DialogContentText from '@mui/material/DialogContentText';
 import DialogTitle from '@mui/material/DialogTitle';
 import Slide from '@mui/material/Slide';
-import { TransitionProps } from '@mui/material/transitions';
 import axios from "axios";
 import { useSessionStorage } from "../customHooks";
 import { STATUS_CODE_FORBIDDEN, STATUS_CODE_OK, STATUS_CODE_UNAUTHORIZED } from "../constants";
 import { URL_USER_SVC } from "../configs";
 import { useNavigate } from "react-router-dom";
 
-const Transition = React.forwardRef(function Transition(
-    props: TransitionProps & {
-        children: React.ReactElement<any, any>;
-    },
-    ref: React.Ref<unknown>,
-) {
+const Transition = React.forwardRef(function Transition(props, ref) {
     return <Slide direction="up" ref={ref} {...props} />;
 });
 
@@ -50,6 +44,7 @@ export default function AlertDialogSlide() {
             })
 
         if (res && res.status === STATUS_CODE_OK) {
+            handleClose();
             console.log(`${username} delete success`)
             navigate("/deleteAccount", { state: { success: true } }) // placeholder until merge with matching
         }
@@ -70,7 +65,7 @@ export default function AlertDialogSlide() {
                 <DialogTitle>{"Delete Account?"}</DialogTitle>
                 <DialogContent>
                     <DialogContentText id="alert-dialog-slide-description">
-                       Are you sure you want to delete your account?
+                        Are you sure you want to delete your account?
                     </DialogContentText>
                 </DialogContent>
                 <DialogActions>

--- a/frontend/src/components/DeleteAccountAlert.js
+++ b/frontend/src/components/DeleteAccountAlert.js
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import Button from '@mui/material/Button';
+import Dialog from '@mui/material/Dialog';
+import DialogActions from '@mui/material/DialogActions';
+import DialogContent from '@mui/material/DialogContent';
+import DialogContentText from '@mui/material/DialogContentText';
+import DialogTitle from '@mui/material/DialogTitle';
+import Slide from '@mui/material/Slide';
+import { TransitionProps } from '@mui/material/transitions';
+import axios from "axios";
+import { useSessionStorage } from "../customHooks";
+import { STATUS_CODE_FORBIDDEN, STATUS_CODE_OK, STATUS_CODE_UNAUTHORIZED } from "../constants";
+import { URL_USER_SVC } from "../configs";
+import { useNavigate } from "react-router-dom";
+
+const Transition = React.forwardRef(function Transition(
+    props: TransitionProps & {
+        children: React.ReactElement<any, any>;
+    },
+    ref: React.Ref<unknown>,
+) {
+    return <Slide direction="up" ref={ref} {...props} />;
+});
+
+export default function AlertDialogSlide() {
+    const [open, setOpen] = React.useState(false);
+    const [username, setUsername] = useSessionStorage('username', '')
+
+    let navigate = useNavigate();
+
+    const handleClickOpen = () => {
+        setOpen(true);
+    };
+
+    const handleClose = () => {
+        setOpen(false);
+    };
+
+    const handleDeleteAccount = async () => {
+        const res = await axios.post(URL_USER_SVC + '/deleteAccount',
+            { username },
+            { withCredentials: true, credentials: 'include' })
+            .catch((err) => {
+                console.log(err)
+                // Either cookie or token expired
+                if (err.response.status === STATUS_CODE_UNAUTHORIZED ||
+                    err.response.status === STATUS_CODE_FORBIDDEN) {
+                    navigate("/login");
+                }
+            })
+
+        if (res && res.status === STATUS_CODE_OK) {
+            console.log(`${username} delete success`)
+            navigate("/deleteAccount", { state: { success: true } }) // placeholder until merge with matching
+        }
+    }
+
+    return (
+        <div>
+            <Button variant="text" onClick={handleClickOpen}>
+                Delete Account
+            </Button>
+            <Dialog
+                open={open}
+                TransitionComponent={Transition}
+                keepMounted
+                onClose={handleClose}
+                aria-describedby="alert-dialog-slide-description"
+            >
+                <DialogTitle>{"Delete Account?"}</DialogTitle>
+                <DialogContent>
+                    <DialogContentText id="alert-dialog-slide-description">
+                       Are you sure you want to delete your account?
+                    </DialogContentText>
+                </DialogContent>
+                <DialogActions>
+                    <Button onClick={handleClose}>Disagree</Button>
+                    <Button onClick={handleDeleteAccount}>Agree</Button>
+                </DialogActions>
+            </Dialog>
+        </div>
+    );
+}

--- a/frontend/src/components/DeleteAccountPage.js
+++ b/frontend/src/components/DeleteAccountPage.js
@@ -1,0 +1,13 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation } from "react-router-dom";
+import { Box, Typography } from "@mui/material";
+
+function DeleteAccountPage(props) {
+    return (
+        <Box display={"flex"} flexDirection={"column"} padding={"4rem"} margin={"auto"}>
+            <Typography variant={"h1"}>"Your account has been successfully deleted."</Typography>
+        </Box>
+    )
+}
+
+export default DeleteAccountPage;

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -41,7 +41,26 @@ function NavBar() {
             navigate("/logout", { state: { success: true } }) // placeholder until merge with matching
         }
     }
-    
+
+    const handleDeleteAccount = async () => {
+        const res = await axios.post(URL_USER_SVC + '/deleteAccount',
+            { username },
+            { withCredentials: true, credentials: 'include' })
+            .catch((err) => {
+                console.log(err)
+                // Either cookie or token expired
+                if (err.response.status === STATUS_CODE_UNAUTHORIZED ||
+                    err.response.status === STATUS_CODE_FORBIDDEN) {
+                    navigate("/login");
+                }
+            })
+
+        if (res && res.status === STATUS_CODE_OK) {
+            console.log(`${username} delete success`)
+            navigate("/deleteAccount", { state: { success: true } }) // placeholder until merge with matching
+        }
+    }
+
     return (
         <Box sx={{ flexGrow: 1 }}>
             <AppBar position="sticky">
@@ -49,25 +68,25 @@ function NavBar() {
                     <Typography variant="h6" sx={{ flexGrow: 1, display: { xs: 'none', sm: 'block' } }}>
                         PeerPrep
                     </Typography>
-                    <Box sx={{ flexGrow: 0}}>
+                    <Box sx={{ flexGrow: 0 }}>
                         <Tooltip title="Open User Settings">
                             <IconButton onClick={handleOpenUserSettings}>
                                 <SettingsIcon />
                             </IconButton>
                         </Tooltip>
-                        
+
                         <Menu
                             sx={{ mt: '45px' }}
                             id="menu-appbar"
                             anchorEl={anchorEl}
                             anchorOrigin={{
-                              vertical: 'top',
-                              horizontal: 'right',
+                                vertical: 'top',
+                                horizontal: 'right',
                             }}
                             keepMounted
                             transformOrigin={{
-                              vertical: 'top',
-                              horizontal: 'right',
+                                vertical: 'top',
+                                horizontal: 'right',
                             }}
                             open={open}
                             onClose={handleCloseUserSettings}
@@ -77,7 +96,11 @@ function NavBar() {
                                     <Link to="/changePassword" style={{ textDecoration: "none" }}>Change Password</Link>
                                 </Typography>
                             </MenuItem>
-                            {/* <MenuItem>Delete Account</MenuItem> */}
+                            <MenuItem onClick={handleDeleteAccount}>
+                                <Typography variant="text" textAlign="center" color="primary">
+                                    Delete Account
+                                </Typography>
+                            </MenuItem>
 
                         </Menu>
                         <Tooltip title="Logout">
@@ -85,12 +108,12 @@ function NavBar() {
                                 <LogoutIcon />
                             </IconButton>
                         </Tooltip>
-                        
+
                     </Box>
                 </Toolbar>
             </AppBar>
         </Box>
-        
+
     )
 }
 

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -75,7 +75,7 @@ function NavBar() {
                             onClose={handleCloseUserSettings}
                         >
                             <MenuItem onClick={handleCloseUserSettings}>
-                                <Button variant="text" textAlign="center" color="primary">
+                                <Button variant="text" style={{ textAlign: "center" }} color="primary">
                                     <Link to="/changePassword" style={{ textDecoration: "none" }}>Change Password</Link>
                                 </Button>
                             </MenuItem>

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -7,6 +7,8 @@ import axios from "axios";
 import { useSessionStorage } from "../customHooks";
 import { STATUS_CODE_FORBIDDEN, STATUS_CODE_OK, STATUS_CODE_UNAUTHORIZED } from "../constants";
 import { URL_USER_SVC } from "../configs";
+import DeleteAccountAlert from "./DeleteAccountAlert";
+import Button from '@mui/material/Button';
 
 function NavBar() {
     const [anchorEl, setAnchorEl] = useState(null)
@@ -42,25 +44,6 @@ function NavBar() {
         }
     }
 
-    const handleDeleteAccount = async () => {
-        const res = await axios.post(URL_USER_SVC + '/deleteAccount',
-            { username },
-            { withCredentials: true, credentials: 'include' })
-            .catch((err) => {
-                console.log(err)
-                // Either cookie or token expired
-                if (err.response.status === STATUS_CODE_UNAUTHORIZED ||
-                    err.response.status === STATUS_CODE_FORBIDDEN) {
-                    navigate("/login");
-                }
-            })
-
-        if (res && res.status === STATUS_CODE_OK) {
-            console.log(`${username} delete success`)
-            navigate("/deleteAccount", { state: { success: true } }) // placeholder until merge with matching
-        }
-    }
-
     return (
         <Box sx={{ flexGrow: 1 }}>
             <AppBar position="sticky">
@@ -92,14 +75,15 @@ function NavBar() {
                             onClose={handleCloseUserSettings}
                         >
                             <MenuItem onClick={handleCloseUserSettings}>
-                                <Typography variant="text" textAlign="center" color="primary">
+                                <Button variant="text" textAlign="center" color="primary">
                                     <Link to="/changePassword" style={{ textDecoration: "none" }}>Change Password</Link>
-                                </Typography>
+                                </Button>
                             </MenuItem>
-                            <MenuItem onClick={handleDeleteAccount}>
-                                <Typography variant="text" textAlign="center" color="primary">
+                            <MenuItem onClick={handleCloseUserSettings}>
+                                {/* <Typography variant="text" textAlign="center" color="primary">
                                     Delete Account
-                                </Typography>
+                                </Typography> */}
+                                <DeleteAccountAlert />
                             </MenuItem>
 
                         </Menu>

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -29,8 +29,10 @@ export async function createUser(req, res) {
             }
 
             if (!verifyPasswordStrength(password)) {
-                return res.status(400).json({ message: 'New password does not meet password strength requirement. ' +
-                    'Passwords should contain at least 8 characters and is a combination of numbers and alphabets.'});
+                return res.status(400).json({
+                    message: 'New password does not meet password strength requirement. '
+                    + 'Passwords should contain at least 8 characters and is a combination of numbers and alphabets.',
+                });
             }
 
             const hashedPassword = await hashSaltPassword(password);
@@ -96,14 +98,16 @@ export async function changePassword(req, res) {
             console.log(`User ${username} has been authenticated.`);
             // verify password strength
             if (oldPassword === newPassword) {
-                return res.status(400).json({ message: 'New password should not be the same as old password'});
+                return res.status(400).json({ message: 'New password should not be the same as old password' });
             }
 
             if (!verifyPasswordStrength(newPassword)) {
-                return res.status(400).json({ message: 'New password does not meet password strength requirement. ' +
-                    'Passwords should contain at least 8 characters and is a combination of numbers and alphabets.'});
+                return res.status(400).json({
+                    message: 'New password does not meet password strength requirement. '
+                    + 'Passwords should contain at least 8 characters and is a combination of numbers and alphabets.',
+                });
             }
-            
+
             // store new password
             const hashedNewPassword = await hashSaltPassword(newPassword);
             const resp = await _updateUser(user, { username: username, password: hashedNewPassword });

--- a/user-service/index.js
+++ b/user-service/index.js
@@ -23,7 +23,7 @@ const router = express.Router();
 // Controller will contain all the User-defined Routes
 // router.get('/', (_, res) => res.send('Hello World from user-service'));
 router.post('/', createUser);
-router.delete('/', authenticateCookieToken, deleteUser, logout);
+router.post('/deleteAccount', authenticateCookieToken, deleteUser, logout);
 router.post('/changePassword', authenticateCookieToken, changePassword);
 router.post('/login', loginUser);
 router.post('/logout', authenticateCookieToken, logout);


### PR DESCRIPTION
Closes #65 

**Summary**
* Implement UI elements for delete account in the NavBar
* Add dialog to prevent accidental deletion of account
* Update delete account route from DELETE to POST, as axios currently do not support `withCredentials` for a `axios.delete`, and the cookie data will never be sent to the backend. 
![image](https://user-images.githubusercontent.com/12153882/195083810-9f9b3fde-13d4-4bab-be7e-d5bc2eecf021.png)
https://github.com/axios/axios/issues/509