### PR TITLE
Update username handling from using Session to Cookies

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -16,6 +16,7 @@
         "@testing-library/react": "^13.3.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^0.27.2",
+        "js-cookie": "^3.0.1",
         "react": "^18.2.0",
         "react-countdown-circle-timer": "^3.0.9",
         "react-dom": "^18.2.0",
@@ -11729,6 +11730,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
+    "node_modules/js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -25692,6 +25701,11 @@
           }
         }
       }
+    },
+    "js-cookie": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.1.tgz",
+      "integrity": "sha512-+0rgsUXZu4ncpPxRL+lNEptWMOWl9etvPHc/koSRp6MPwpRYAhmk0dUG00J4bxVV3r9uUzfo24wW0knS07SKSw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "@testing-library/react": "^13.3.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^0.27.2",
+    "js-cookie": "^3.0.1",
     "react": "^18.2.0",
     "react-countdown-circle-timer": "^3.0.9",
     "react-dom": "^18.2.0",

--- a/frontend/src/components/ChangePasswordPage.js
+++ b/frontend/src/components/ChangePasswordPage.js
@@ -1,13 +1,13 @@
+import React, { Fragment, useState } from 'react';
 import { Alert, Box, Button, IconButton, Snackbar, Stack, TextField, Typography } from "@mui/material";
 import CloseIcon from '@mui/icons-material/Close';
 import axios from "axios";
-import { Fragment, useState } from "react";
 import { URL_USER_SVC } from "../configs";
 import { STATUS_CODE_BADREQUEST, STATUS_CODE_OK, STATUS_CODE_UNAUTHORIZED } from "../constants";
-import { useSessionStorage } from "../customHooks";
+import Cookies from 'js-cookie';
 
 function ChangePasswordPage() {
-    const [username, setUsername] = useSessionStorage('username' ,"")
+    const [username, setUsername] = useState(Cookies.get('username'));
     const [oldPassword, setOldPassword] = useState("")
     const [newPassword, setNewPassword] = useState("")
     const [newPasswordTwo, setNewPasswordTwo] = useState("")
@@ -26,7 +26,7 @@ function ChangePasswordPage() {
             setOpen(true)
             setErrorMsg('Please check that inputs are non-empty and valid')
         } else {
-            const res = await axios.post(URL_USER_SVC + '/changePassword', 
+            const res = await axios.post(URL_USER_SVC + '/changePassword',
                 { username, oldPassword, newPassword },
                 { withCredentials: true, credentials: 'include' })
                 .catch((err) => {
@@ -113,13 +113,13 @@ function ChangePasswordPage() {
                 <Typography variant={"subtitle1"}>
                     Your new password should be alphanumeric and be at least length 8
                 </Typography>
-                <TextField 
+                <TextField
                     disabled
-                    label="Username" 
+                    label="Username"
                     variant="standard"
                     value={username}
                 />
-                <TextField 
+                <TextField
                     required
                     label="Current Password"
                     variant="standard"
@@ -129,7 +129,7 @@ function ChangePasswordPage() {
                     onChange={(e) => setOldPassword(e.target.value)}
                     onBlur={checkOldPwNotMatchNewPw}
                 />
-                <TextField 
+                <TextField
                     required
                     label="New Password"
                     variant="standard"
@@ -137,11 +137,11 @@ function ChangePasswordPage() {
                     placeholder="Type your new password"
                     value={newPassword}
                     onChange={(e) => setNewPassword(e.target.value)}
-                    onBlur={(e) => {validatePasswordStrength(e); checkNewPasswordsMatch(e);}}
+                    onBlur={(e) => { validatePasswordStrength(e); checkNewPasswordsMatch(e); }}
                     error={passwordStrengthMsg !== ''}
                     helperText={passwordStrengthMsg}
                 />
-                <TextField 
+                <TextField
                     required
                     label="Confirm New Password"
                     variant="standard"
@@ -156,7 +156,7 @@ function ChangePasswordPage() {
                 <Box display={"flex"} flexDirection={"row"} justifyContent={"flex-end"}>
                     <Button variant={"outlined"} onClick={handleChangePassword}>Submit</Button>
                 </Box>
-                {isSuccess && 
+                {isSuccess &&
                     <Snackbar
                         anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
                         open={isSuccess}
@@ -181,7 +181,7 @@ function ChangePasswordPage() {
                 </Alert>
             </Snackbar>
         </Box>
-    ); 
+    );
 }
 
 export default ChangePasswordPage;

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -1,12 +1,12 @@
+import React, { useState } from 'react';
 import { Box, Typography } from "@mui/material";
-import { useNavigate, useLocation } from "react-router-dom";
-import { useSessionStorage } from "../customHooks";
+import Cookies from 'js-cookie';
 
 function Home(props) {
-    const [ username, setUsername ] = useSessionStorage('username', 'NOT LOGGED IN USER') //|| 'NOT LOGGED IN USER'; // Read values passed on state
+    const [username, setUsername] = useState(Cookies.get('username'));
 
     return (
-        <Box style={{ margin: "auto" }} display={"flex"} flexDirection={"column"} justify-content={"center"} 
+        <Box style={{ margin: "auto" }} display={"flex"} flexDirection={"column"} justify-content={"center"}
             padding={"4rem"}>
             <Typography variant={"h3"}>HOME PAGE PLACEHOLDER, Welcome back {username}!</Typography>
         </Box>)

--- a/frontend/src/components/Home.js
+++ b/frontend/src/components/Home.js
@@ -3,10 +3,7 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { useSessionStorage } from "../customHooks";
 
 function Home(props) {
-    let navigate = useNavigate();
-
-    const { state } = useLocation();
-    const [ username, setUsername ] = useSessionStorage('username', state.username) //|| 'NOT LOGGED IN USER'; // Read values passed on state
+    const [ username, setUsername ] = useSessionStorage('username', 'NOT LOGGED IN USER') //|| 'NOT LOGGED IN USER'; // Read values passed on state
 
     return (
         <Box style={{ margin: "auto" }} display={"flex"} flexDirection={"column"} justify-content={"center"} 

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -5,11 +5,9 @@ import axios from "axios";
 import { STATUS_CODE_OK, STATUS_CODE_UNAUTHORIZED } from "../constants";
 import { URL_USER_SVC } from "../configs";
 import { useNavigate } from "react-router-dom";
-import { useSessionStorage } from "../customHooks";
 
 function LoginPage() {
     const [username, setUsername] = useState('')
-    const [sessionUsername, setSessionUsername] = useSessionStorage('username', '')
     const [password, setPassword] = useState("")
     const [errorMsg, setErrorMsg] = useState("")
     const [open, setOpen] = useState(false)
@@ -35,7 +33,6 @@ function LoginPage() {
         if (res && res.status === STATUS_CODE_OK) {
             console.log(`${username} login success`)
             // set session storage username
-            setSessionUsername(`${username}`) // ISSUE: setSessionUsername not working here since it's sync function
             navigate("/home") // placeholder until merge with matching
         }
     }

--- a/frontend/src/components/LoginPage.js
+++ b/frontend/src/components/LoginPage.js
@@ -36,7 +36,7 @@ function LoginPage() {
             console.log(`${username} login success`)
             // set session storage username
             setSessionUsername(`${username}`) // ISSUE: setSessionUsername not working here since it's sync function
-            navigate("/home", { state: { username: username } }) // placeholder until merge with matching
+            navigate("/home") // placeholder until merge with matching
         }
     }
 

--- a/frontend/src/components/NavBar.js
+++ b/frontend/src/components/NavBar.js
@@ -7,11 +7,12 @@ import axios from "axios";
 import { useSessionStorage } from "../customHooks";
 import { STATUS_CODE_FORBIDDEN, STATUS_CODE_OK, STATUS_CODE_UNAUTHORIZED } from "../constants";
 import { URL_USER_SVC } from "../configs";
+import Cookies from 'js-cookie';
 
 function NavBar() {
     const [anchorEl, setAnchorEl] = useState(null)
     const open = Boolean(anchorEl)
-    const [username, setUsername] = useSessionStorage('username', '')
+    const [username, setUsername] = useState(Cookies.get('username'));
 
     const handleOpenUserSettings = (e) => {
         setAnchorEl(e.currentTarget)

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -143,6 +143,7 @@ export async function loginUser(req, res) {
     // Store token in cookie
     res.cookie('token', token, { expires: new Date(Date.now() + (30 * 60 * 1000)), httpOnly: true });
     res.cookie('refreshToken', refreshToken, { expires: new Date(Date.now() + (30 * 60 * 1000)), httpOnly: true });
+    res.cookie('username', req.body.username, { expires: new Date(Date.now() + (30 * 60 * 1000)) });
 
     return res.status(200).json({
         message: `${user.username} has been authenticated`,

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -226,6 +226,7 @@ export async function logout(req, res) {
     // Delete cookies
     res.clearCookie('token');
     res.clearCookie('refreshToken');
+    res.clearCookie('username');
 
     return res.status(200).json({ message: 'Logout successful!' });
 }


### PR DESCRIPTION
Fixes #94 

**Summary**
* ~~Update useSessionStorage() to use a default string value rather than navigate() params~~
* Update username read/write to use cookies instead of storage
* Pages updated with this new functionality in this PR: `Home` and `ChangePassword`

**Steps to test**
1. `npm install` in the frontend directory
2. Perform a login in the frontend
3. Manually type out `http://localhost:3000/home` in the URL bar and hit enter
4. Expected result: the home page renders without crashing. (It would be a white screen before this fix). A cookie 'username' is present on the browser that supplies the username to the application.