### PR TITLE
Fix SignUp Page password strength error display bug

### DIFF
--- a/frontend/src/components/SignupPage.js
+++ b/frontend/src/components/SignupPage.js
@@ -12,7 +12,7 @@ import {
 import {useState} from "react";
 import axios from "axios";
 import {URL_USER_SVC} from "../configs";
-import {STATUS_CODE_CONFLICT, STATUS_CODE_CREATED} from "../constants";
+import {STATUS_CODE_BADREQUEST, STATUS_CODE_CONFLICT, STATUS_CODE_CREATED} from "../constants";
 import {Link} from "react-router-dom";
 
 function SignupPage() {
@@ -29,6 +29,8 @@ function SignupPage() {
             .catch((err) => {
                 if (err.response.status === STATUS_CODE_CONFLICT) {
                     setErrorDialog('This username already exists')
+                } else if (err.response.status === STATUS_CODE_BADREQUEST) {
+                    setErrorDialog(err.response.data.message)
                 } else {
                     setErrorDialog('Please try again later')
                 }
@@ -72,6 +74,7 @@ function SignupPage() {
                 type="password"
                 value={password}
                 onChange={(e) => setPassword(e.target.value)}
+                helperText="Password should contain at least 8 characters and is alphanumeric"
                 sx={{marginBottom: "2rem"}}
             />
             <Box display={"flex"} flexDirection={"row"} justifyContent={"flex-end"}>

--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -29,7 +29,7 @@ export async function createUser(req, res) {
             }
 
             if (!verifyPasswordStrength(password)) {
-                return res.status(400).json({ message: 'New password does not meet password strength requirement. ' +
+                return res.status(400).json({ message: 'Password does not meet password strength requirement. ' +
                     'Passwords should contain at least 8 characters and is a combination of numbers and alphabets.'});
             }
 


### PR DESCRIPTION
Fixes #102 

Summary:
- Previously, generic error shows when a weak password was used.
- Shows specific error message for weak password

![image](https://user-images.githubusercontent.com/65227564/195869579-657c7d03-ac27-42b7-a987-d90ebcd51b52.png)
