### PR TITLE
Implement standalone endpoint for authentication

### DIFF
--- a/user-service/controller/user-controller.js
+++ b/user-service/controller/user-controller.js
@@ -228,3 +228,7 @@ export async function logout(req, res) {
 
     return res.status(200).json({ message: 'Logout successful!' });
 }
+
+export async function sendAuthSuccess(req, res) {
+    return res.status(200).json({ message: 'Authentication Successful!' });
+}

--- a/user-service/index.js
+++ b/user-service/index.js
@@ -8,6 +8,7 @@ import {
     logout,
     authenticateCookieToken,
     changePassword,
+    sendAuthSuccess,
 } from './controller/user-controller.js';
 
 const app = express();
@@ -27,6 +28,7 @@ router.delete('/', authenticateCookieToken, deleteUser, logout);
 router.post('/changePassword', authenticateCookieToken, changePassword);
 router.post('/login', loginUser);
 router.post('/logout', authenticateCookieToken, logout);
+router.post('/auth', authenticateCookieToken, sendAuthSuccess);
 
 app.use('/api/user', router).all((_, res) => {
     res.setHeader('content-type', 'application/json');


### PR DESCRIPTION
Closes #116 

**Summary**
* Currently, authentication is built-in in user-service endpoints that require it. (E.g. changePassword, logout etc)
* Implement standalone endpoint for authentication at `POST /auth`
* This can be used for checks when the desired outcome after authentication is outside of user-service responsibilities.