### PR TITLE
Implement History Service API

### DIFF
--- a/history-service/.env
+++ b/history-service/.env
@@ -1,2 +1,2 @@
-DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/?retryWrites=true&w=majority
+DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/history?retryWrites=true&w=majority
 ENV=PROD

--- a/history-service/.env
+++ b/history-service/.env
@@ -1,2 +1,3 @@
 DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/history?retryWrites=true&w=majority
-ENV=PROD
+DB_CLOUD_URI_DEV=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/test?retryWrites=true&w=majority
+ENV=DEV

--- a/history-service/.env
+++ b/history-service/.env
@@ -1,0 +1,2 @@
+DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/?retryWrites=true&w=majority
+ENV=PROD

--- a/history-service/controller/history-controller.js
+++ b/history-service/controller/history-controller.js
@@ -1,0 +1,43 @@
+import { ormGetRecords, ormStoreRecord } from "../model/history-orm.js";
+
+export async function storeRecord(req, res) {
+    try {
+        const { username } = req.params;
+        const { questionTitle, questionDifficulty } = req.body;
+
+        if (questionTitle && questionDifficulty) {
+            const storedRecord = await ormStoreRecord(username, {questionTitle, questionDifficulty});
+            if (storedRecord.err) {
+                return res.status(400).json({ message: `Could not save record of question - ${questionTitle} to ${username} !` });
+            }
+
+            console.log(`Successfully added ${questionTitle} to ${username}'s records`);
+
+            if (storeRecord.status === 'created') {
+                res.status(201);
+            } else if (storeRecord.status === 'updated') {
+                res.status(200);
+            }
+            return res.json({ message: `Successfully added ${questionTitle} to ${username}'s records` });
+        }
+
+        return res.status(400).json({ message: 'Question Info is missing!' });
+    } catch (err) {
+        return res.status(500).json({ message: 'Database failure when storing record'});
+    }
+}
+
+export async function getRecord(req, res) {
+    try {
+        const { username } = req.params;
+
+        const resp = await ormGetRecords(username);
+        if (resp.err) {
+            return res.status(400).json({ message: 'Could not retrieve records for ' + username});
+        }
+
+        return res.status(200).json({ message: `Successfully retrieved ${username}'s records!`, data: resp});
+    } catch (err) {
+        return res.status(500).json({ message: 'Database failure when storing record'});
+    }
+}

--- a/history-service/controller/history-controller.js
+++ b/history-service/controller/history-controller.js
@@ -8,7 +8,8 @@ export async function storeRecord(req, res) {
         if (questionTitle && questionDifficulty) {
             const storedRecord = await ormStoreRecord(username, {questionTitle, questionDifficulty});
             if (storedRecord.err) {
-                return res.status(400).json({ message: `Could not save record of question - ${questionTitle} to ${username} !` });
+                return res.status(400)
+                    .json({ message: `Could not save record of question - ${questionTitle} to ${username}!` });
             }
 
             console.log(`Successfully added ${questionTitle} to ${username}'s records`);
@@ -21,7 +22,7 @@ export async function storeRecord(req, res) {
             return res.json({ message: `Successfully added ${questionTitle} to ${username}'s records` });
         }
 
-        return res.status(400).json({ message: 'Question Info is missing!' });
+        return res.status(400).json({ message: 'Question Title and/or Question Difficulty is missing!' });
     } catch (err) {
         return res.status(500).json({ message: 'Database failure when storing record'});
     }
@@ -30,13 +31,22 @@ export async function storeRecord(req, res) {
 export async function getRecord(req, res) {
     try {
         const { username } = req.params;
+        const level = req.query.level;
 
         const resp = await ormGetRecords(username);
         if (resp.err) {
             return res.status(400).json({ message: 'Could not retrieve records for ' + username});
         }
 
-        return res.status(200).json({ message: `Successfully retrieved ${username}'s records!`, data: resp});
+        if (!level) {
+            return res.status(200).json({ message: `Successfully retrieved ${username}'s records!`, data: resp});
+        }
+
+        // filter the records based on level
+        const filteredRecords = resp.records.filter(r => r.questionDifficulty === level) || [];
+        const filteredResp = {_id: resp._id, username: resp.username, filteredRecords};
+
+        return res.status(200).json({ message: `Successfully retrieved ${username}'s records!`, data: filteredResp });
     } catch (err) {
         return res.status(500).json({ message: 'Database failure when storing record'});
     }

--- a/history-service/index.js
+++ b/history-service/index.js
@@ -1,0 +1,20 @@
+import express from 'express';
+import cors from 'cors';
+import { getRecord, storeRecord } from './controller/history-controller.js';
+
+const app = express();
+app.use(express.urlencoded({ extended: true }));
+app.use(express.json());
+app.options('*', cors());
+
+const router = express.Router();
+
+router.get('/:username', getRecord);
+router.put('/:username', storeRecord);
+
+app.use('/api/history', router).all((_, res) => {
+    res.setHeader('content-type', 'application/json');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+});
+
+app.listen(8003, () => console.log('history-service listening on port 8003'));

--- a/history-service/model/history-model.js
+++ b/history-service/model/history-model.js
@@ -1,0 +1,22 @@
+import mongoose from 'mongoose';
+
+const { Schema } = mongoose;
+const HistoryModelSchema = new Schema({
+    username: {
+        type: String,
+        required: true,
+        unique: true,
+    },
+    records: {
+        type: [{ 
+            questionTitle: {
+                type: String,
+                unique: true,
+            },
+            questionDifficulty: String
+         }],
+        required: true,
+    }
+});
+
+export default mongoose.model('HistoryModel', HistoryModelSchema);

--- a/history-service/model/history-model.js
+++ b/history-service/model/history-model.js
@@ -9,11 +9,8 @@ const HistoryModelSchema = new Schema({
     },
     records: {
         type: [{ 
-            questionTitle: {
-                type: String,
-                unique: true,
-            },
-            questionDifficulty: String
+            questionTitle: String,
+            questionDifficulty: String,
          }],
         required: true,
     }

--- a/history-service/model/history-orm.js
+++ b/history-service/model/history-orm.js
@@ -1,0 +1,37 @@
+import { createRecord, findRecord } from "./repository.js";
+
+
+export async function ormStoreRecord(username, newQuestion) {
+    try {
+        // if no records exist for this user -> create new model
+        const userRecord = await findRecord(username);
+
+        if (!userRecord) {
+            const newRecord = await createRecord({username, records: [newQuestion]});
+            newRecord.save();
+            return { status: 'created' };
+        } else {
+            // otherwise update existing records
+            if (!userRecord.records.some(r => r.questionTitle === newQuestion.questionTitle)) {
+                userRecord.records.push(newQuestion);
+                userRecord.save();
+            }
+
+            return { status: 'updated'};
+        }
+    } catch (err) {
+        console.log('ERROR: Could not save record');
+        return { err };
+    }
+}
+
+
+export async function ormGetRecords(username) {
+    try {
+        const userRecord = await findRecord(username);
+        return userRecord;
+    } catch (err) {
+        console.log('ERROR: Could not get record');
+        return { err };
+    }
+}

--- a/history-service/model/history-orm.js
+++ b/history-service/model/history-orm.js
@@ -12,9 +12,11 @@ export async function ormStoreRecord(username, newQuestion) {
             return { status: 'created' };
         } else {
             // otherwise update existing records
-            if (!userRecord.records.some(r => r.questionTitle === newQuestion.questionTitle)) {
+            if (!userRecord.records.some(r => r.questionTitle === newQuestion.questionTitle && r.questionDifficulty === newQuestion.questionDifficulty)) {
                 userRecord.records.push(newQuestion);
                 userRecord.save();
+            } else {
+                console.log('Question Title already exists!');
             }
 
             return { status: 'updated'};
@@ -29,6 +31,7 @@ export async function ormStoreRecord(username, newQuestion) {
 export async function ormGetRecords(username) {
     try {
         const userRecord = await findRecord(username);
+        
         return userRecord;
     } catch (err) {
         console.log('ERROR: Could not get record');

--- a/history-service/model/repository.js
+++ b/history-service/model/repository.js
@@ -4,7 +4,7 @@ import mongoose from 'mongoose';
 import 'dotenv/config';
 import historyModel from './history-model.js';
 
-const mongoDB = process.env.ENV === 'PROD' ? process.env.DB_CLOUD_URI : process.env.DB_LOCAL_URI;
+const mongoDB = process.env.ENV === 'PROD' ? process.env.DB_CLOUD_URI : process.env.DB_CLOUD_URI_DEV;
 
 mongoose.connect(mongoDB, { useNewUrlParser: true, useUnifiedTopology: true });
 

--- a/history-service/model/repository.js
+++ b/history-service/model/repository.js
@@ -1,0 +1,22 @@
+// Set up mongoose connection
+import mongoose from 'mongoose';
+
+import 'dotenv/config';
+import historyModel from './history-model.js';
+
+const mongoDB = process.env.ENV === 'PROD' ? process.env.DB_CLOUD_URI : process.env.DB_LOCAL_URI;
+
+mongoose.connect(mongoDB, { useNewUrlParser: true, useUnifiedTopology: true });
+
+const db = mongoose.connection;
+db.on('error', console.error.bind(console, 'MongoDB connection error:'));
+
+export async function findRecord(username) {
+    return historyModel.findOne({ username: username });
+}
+
+export async function createRecord(params) {
+    // params contain a username and question
+    console.log(params);
+    return new historyModel(params);
+}

--- a/history-service/package.json
+++ b/history-service/package.json
@@ -1,0 +1,23 @@
+{
+    "name": "history-service",
+    "version": "1.0.0",
+    "description": "",
+    "main": "index.js",
+    "type": "module",
+    "scripts": {
+      "dev": "nodemon index.js",
+      "start": "node index.js",
+      "test": "echo \"Error: no test specified\" && exit 1"
+    },
+    "author": "",
+    "license": "ISC",
+    "devDependencies": {
+      "nodemon": "^2.0.19"
+    },
+    "dependencies": {
+      "cors": "^2.8.5",
+      "dotenv": "^16.0.3",
+      "express": "^4.18.2",
+      "mongoose": "^6.6.5"
+    }
+  }


### PR DESCRIPTION
Fixes #133 

Summary:
- Add new `HistoryModel` schema to mongodb
- Add PUT API to save attempted question into user's history - will create a new record if there is no existing record for the user, otherwise update the records for the user
- Add GET API to retrieve user's list of attempted question

More Information:

- `HistoryModel` contains a unique `username` as identifier, and `records`, which is an array of object {`questionTitle`, `questionDifficulty`}
- APIs are defined as below:
  -  `GET /api/history/:username`. You can add a query `?level=<DIFFICULTY>` where `DIFFICULTY = easy | medium | hard` to filter the list of attempted questions of a username
    - Can be used to display total questions attempted on the frontend
  - `PUT /api/history/:username` with requestBody : `{ questionTitle, questionDifficulty }`

How to test:
1. `npm i`, `npm run dev`
2. In postman: try creating and updating the records for a user
![image](https://user-images.githubusercontent.com/65227564/198872714-ce3298ed-6493-487c-8d4c-3b5616bc9989.png)

3. In postman, try retrieving the user's records
![image](https://user-images.githubusercontent.com/65227564/198872737-20f84332-d992-49a1-8977-b06138b8b822.png)

Discussion:
- Should we create API to retrieve 5 most recent questions? - would require dealing with dates, which is more complicated