### PR TITLE
Add Prod DB URL

### DIFF
--- a/question-service/.env
+++ b/question-service/.env
@@ -1,3 +1,4 @@
-DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/?retryWrites=true&w=majority
+DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/questions?retryWrites=true&w=majority
+DB_CLOUD_URI_DEV=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/test?retryWrites=true&w=majority
 # DB_LOCAL_URI=mongodb://localhost/${KEY_IN_YOUR_DB_HERE}
-ENV=PROD
+ENV=DEV

--- a/question-service/model/repository.js
+++ b/question-service/model/repository.js
@@ -4,7 +4,7 @@ import mongoose from 'mongoose';
 import QuestionModel from './question-model.js';
 import 'dotenv/config';
 
-const mongoDB = process.env.ENV === 'PROD' ? process.env.DB_CLOUD_URI : process.env.DB_LOCAL_URI;
+const mongoDB = process.env.ENV === 'PROD' ? process.env.DB_CLOUD_URI : process.env.DB_CLOUD_URI_DEV;
 
 mongoose.connect(mongoDB, { useNewUrlParser: true, useUnifiedTopology: true });
 

--- a/user-service/.env
+++ b/user-service/.env
@@ -1,5 +1,5 @@
-DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/?retryWrites=true&w=majority
-# DB_LOCAL_URI=mongodb://localhost/${KEY_IN_YOUR_DB_HERE}
-ENV=PROD
+DB_CLOUD_URI=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/users?retryWrites=true&w=majority
+DB_CLOUD_URI_DEV=mongodb+srv://admin:dHRMfkHaSgSLzBnk@cluster1.aoqygqq.mongodb.net/test?retryWrites=true&w=majority
+ENV=DEV
 ACCESS_TOKEN_SECRET=3b7f125d4600dd167e6d996e31755f35d05e731efecfa6f5a11261bb7c2d3d97acf62bc6e0cc317b6dc9b3ae07da82f2be1569f4d448e997f89d5328c0e8baca
 REFRESH_TOKEN_SECRET=9a942890bf17a16b118c4c109b23f2a50c411998c244dbd9e258bf5a6ecf7e2fbca9ba8210be5d8376b1a450c35e13dbf3596d022209e6d21a7ff063399e8348

--- a/user-service/model/repository.js
+++ b/user-service/model/repository.js
@@ -4,7 +4,7 @@ import mongoose from 'mongoose';
 import UserModel from './user-model.js';
 import 'dotenv/config';
 
-const mongoDB = process.env.ENV === 'PROD' ? process.env.DB_CLOUD_URI : process.env.DB_LOCAL_URI;
+const mongoDB = process.env.ENV === 'PROD' ? process.env.DB_CLOUD_URI : process.env.DB_CLOUD_URI_DEV;
 
 mongoose.connect(mongoDB, { useNewUrlParser: true, useUnifiedTopology: true });
 


### PR DESCRIPTION
**Summary**:
- Microservices using mongodb were found to be using the same database
- Separate DB for user and question microservices in `PROD` - /users and /questions
- Use `/test` database in `DEV`
- changed `ENV` to `DEV`